### PR TITLE
ysl: update fstab.qcom

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -3,11 +3,7 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
 #<src>						<mnt_point>		<type>	<mnt_flags and options>						<fs_mgr_flags>
-/dev/block/bootdevice/by-name/boot		/boot			emmc	defaults							defaults
-/dev/block/bootdevice/by-name/recovery		/recovery		emmc	defaults							defaults
 
-/dev/block/bootdevice/by-name/system		/system			ext4	ro								wait,recoveryonly
-/dev/block/bootdevice/by-name/vendor		/vendor			ext4	ro								wait,recoveryonly
 /dev/block/bootdevice/by-name/userdata		/data			f2fs	nosuid,nodev,noatime,data_flush					wait,check,encryptable=footer,quota,formattable
 /dev/block/bootdevice/by-name/userdata		/data			ext4	nosuid,nodev,noatime,noauto_da_alloc				wait,check,encryptable=footer,quota,formattable
 /dev/block/bootdevice/by-name/cache		/cache			f2fs	nosuid,nodev,noatime,inline_xattr,flush_merge,data_flush	wait,formattable,check
@@ -20,3 +16,8 @@
 
 /devices/soc/7864900.sdhci/mmc_host*		auto			auto	defaults							wait,voldmanaged=sdcard1:auto,noemulatedsd,encryptable=userdata
 /devices/soc/7000000.ssusb/7000000.dwc3/xhci-hcd.0.auto*     auto	auto    defaults							wait,voldmanaged=usb:auto
+
+/dev/block/bootdevice/by-name/system		/system			ext4	ro								wait,recoveryonly
+/dev/block/bootdevice/by-name/vendor		/vendor			ext4	ro								wait,recoveryonly
+/dev/block/bootdevice/by-name/boot		/boot			emmc	defaults							defaults
+/dev/block/bootdevice/by-name/recovery		/recovery		emmc	defaults							defaults


### PR DESCRIPTION
This moves the system and vendor partition to the end of the fstab.qcom
If it stays at the top init gets confused with the fstab and early-init dts entries and could potentially refuse to mount any other partitions.
Put those partitions at the end so theres no issue mounting data or any firmware related files.

Alternatively create a seperate fstab.twrp and remove the system and data mount points completely from this.